### PR TITLE
Fix incomplete type error

### DIFF
--- a/src/recommendationslabel.cpp
+++ b/src/recommendationslabel.cpp
@@ -21,6 +21,7 @@
 
 #include <QPainter>
 #include <QMap>
+#include <QMouseEvent>
 
 const int RecommendationsLabel::CELL_MARGIN = 8;
 const int RecommendationsLabel::CELLS_MAX = 64;


### PR DESCRIPTION
This PR fixes a compilation error, when compiled against QT 5.15.10.

```
x86_64-pc-linux-gnu-g++ -c -march=native -O2 -pipe -Wall -Wextra -D_REENTRANT -fPIC -DQT_DEPRECATED_WARNINGS -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -Isrc -I. -I/usr/include/qt5 -I/usr/include/qt5/QtWidgets -I/usr/include/qt5/QtGui -I/usr/include/qt5/QtCore -I. -I/usr/include/libdrm -I. -I/usr/lib64/qt5/mkspecs/linux-g++ -o recommendationslabel.o src/recommendationslabel.cpp
src/recommendationslabel.cpp: In member function ‘virtual void RecommendationsLabel::mouseMoveEvent(QMouseEvent*)’:
src/recommendationslabel.cpp:42:61: error: invalid use of incomplete type ‘class QMouseEvent’
   42 |     emit recommendationHover(calcRecommendedHoverIndex(event->pos()));
      |                                                             ^~
In file included from /usr/include/qt5/QtWidgets/qframe.h:44,
                 from /usr/include/qt5/QtWidgets/qlabel.h:44,
                 from /usr/include/qt5/QtWidgets/QLabel:1,
                 from src/recommendationslabel.h:24,
                 from src/recommendationslabel.cpp:20:
/usr/include/qt5/QtWidgets/qwidget.h:72:7: note: forward declaration of ‘class QMouseEvent’
   72 | class QMouseEvent;
      |       ^~~~~~~~~~~
src/recommendationslabel.cpp: In member function ‘virtual void RecommendationsLabel::mousePressEvent(QMouseEvent*)’:
src/recommendationslabel.cpp:52:48: error: invalid use of incomplete type ‘class QMouseEvent’
   52 |     int index = calcRecommendedHoverIndex(event->pos());
      |                                                ^~
/usr/include/qt5/QtWidgets/qwidget.h:72:7: note: forward declaration of ‘class QMouseEvent’
   72 | class QMouseEvent;
      |       ^~~~~~~~~~~
make: *** [Makefile:1294: recommendationslabel.o] Error 1
```