### PR TITLE
Fix deprecation warnings

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -66,7 +66,6 @@ void MainWindow::on_actionNew_case_triggered()
         QFileDialog dialog(this);
         dialog.setWindowTitle("New case: Please select a directory with .bmp RDP cache images");
         dialog.setAcceptMode(QFileDialog::AcceptOpen);
-        dialog.setFileMode(QFileDialog::DirectoryOnly);
         dialog.setOption(QFileDialog::ShowDirsOnly, false);
         dialog.setViewMode(QFileDialog::Detail);
         if (dialog.exec() == QDialog::Accepted) {

--- a/src/tilestore.cpp
+++ b/src/tilestore.cpp
@@ -78,7 +78,7 @@ QString TileStore::loadTiles(QString dir)
             tileSize = t.size;
             useCounts.append(0);
             // Check for duplicate
-            uint hash = qHashBits(t.getImage().constBits(), t.getImage().byteCount());
+            uint hash = qHashBits(t.getImage().constBits(), t.getImage().sizeInBytes());
             if (imageHashes.contains(hash)) {
                 t.isDuplicate = true;
                 numDuplicates++;


### PR DESCRIPTION
This PR fixes the following deprecation warnings:

1. Use of `QImage::byteCount()`

```
x86_64-pc-linux-gnu-g++ -c -march=native -O2 -pipe -Wall -Wextra -D_REENTRANT -fPIC -DQT_DEPRECATED_WARNINGS -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -Isrc -I. -I/usr/include/qt5 -I/usr/include/qt5/QtWidgets -I/usr/include/qt5/QtGui -I/usr/include/qt5/QtCore -I. -I/usr/include/libdrm -I. -I/usr/lib64/qt5/mkspecs/linux-g++ -o tilestore.o src/tilestore.cpp
src/tilestore.cpp: In member function ‘QString TileStore::loadTiles(QString)’:
src/tilestore.cpp:81:83: warning: ‘int QImage::byteCount() const’ is deprecated: Use sizeInBytes [-Wdeprecated-declarations]
   81 |             uint hash = qHashBits(t.getImage().constBits(), t.getImage().byteCount());
      |                                                             ~~~~~~~~~~~~~~~~~~~~~~^~
In file included from /usr/include/qt5/QtGui/QImage:1,
                 from src/tile.h:24,
                 from src/tilestore.h:26,
                 from src/tilestore.cpp:20:
/usr/include/qt5/QtGui/qimage.h:221:44: note: declared here
  221 |     QT_DEPRECATED_X("Use sizeInBytes") int byteCount() const;
      |                                            ^~~~~~~~~
```

2. Use of `QFileDialog::DirectoryOnly`

```
x86_64-pc-linux-gnu-g++ -c -march=native -O2 -pipe -Wall -Wextra -D_REENTRANT -fPIC -DQT_DEPRECATED_WARNINGS -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -Isrc -I. -I/usr/include/qt5 -I/usr/include/qt5/QtWidgets -I/usr/include/qt5/QtGui -I/usr/include/qt5/QtCore -I. -I/usr/include/libdrm -I. -I/usr/lib64/qt5/mkspecs/linux-g++ -o mainwindow.o src/mainwindow.cpp
src/mainwindow.cpp: In member function ‘void MainWindow::on_actionNew_case_triggered()’:
src/mainwindow.cpp:69:41: warning: ‘QFileDialog::DirectoryOnly’ is deprecated: Use setOption(ShowDirsOnly, true) instead [-Wdeprecated-declarations]
   69 |         dialog.setFileMode(QFileDialog::DirectoryOnly);
      |                                         ^~~~~~~~~~~~~
In file included from /usr/include/qt5/QtWidgets/QFileDialog:1,
                 from src/mainwindow.cpp:24:
/usr/include/qt5/QtWidgets/qfiledialog.h:84:21: note: declared here
   84 |                     DirectoryOnly Q_DECL_ENUMERATOR_DEPRECATED_X("Use setOption(ShowDirsOnly, true) instead")};
      |                     ^~~~~~~~~~~~~
src/mainwindow.cpp:69:41: warning: ‘QFileDialog::DirectoryOnly’ is deprecated: Use setOption(ShowDirsOnly, true) instead [-Wdeprecated-declarations]
   69 |         dialog.setFileMode(QFileDialog::DirectoryOnly);
      |                                         ^~~~~~~~~~~~~
/usr/include/qt5/QtWidgets/qfiledialog.h:84:21: note: declared here
   84 |                     DirectoryOnly Q_DECL_ENUMERATOR_DEPRECATED_X("Use setOption(ShowDirsOnly, true) instead")};
      |                     ^~~~~~~~~~~~~
```

The fix for 1. requires at least Qt 5.10.

To fix 2., the Qt docs recommend to replace `dialog.setFileMode(QFileDialog::DirectoryOnly)` by `dialog.setFileMode(QFileDialog::Directory)`. But this would lead to a dialog just displaying directories. The RdpCacheStitcher docs states this as intended behavior, but the following code assumes a file to be selected and splits the directory part of this file path afterwards. Thus the line `dialog.setFileMode(QFileDialog::DirectoryOnly)` was dropped without replacement. If it's intended to just select directories a rewrite of this code logic would be advisable.